### PR TITLE
Fix bonus title, table styling

### DIFF
--- a/_posts/2024-04-13-bonus.md
+++ b/_posts/2024-04-13-bonus.md
@@ -4,11 +4,10 @@ title: Mars 2024 BONUSUTGÅVE
 author: Bestem0r
 ---
 
-# Mars 2024 BONUSUTGÅVE
-
 Påskeeggjakta er over og i forrige utgåve vart dei gjeve vinnarane kåra 🏆. Men eitt viktig spørsmål står framleis att: Kvar kunne du finne alle dei **21** påskeegga? 🤔
 Vel, min kjære lesar. Dette treng du ikkje lenger lure på, for her kjem nemleg den store **FASITEN** til årets påskeeggjakt! 🙌
 
+<br>
 |**Nummer**|**Stad**|**Bilete**|
 |**0.**|Lenkje skriven til konsollen på abakus.no.|![0](/images/posts/2024-04-13-egg-0.png)|
 |**2.**|Nederst på framsida til abakus.no.|![2](/images/posts/2024-04-13-egg-2.png)|

--- a/_posts/2024-04-13-bonus.md
+++ b/_posts/2024-04-13-bonus.md
@@ -6,8 +6,8 @@ author: Bestem0r
 
 Påskeeggjakta er over og i forrige utgåve vart dei gjeve vinnarane kåra 🏆. Men eitt viktig spørsmål står framleis att: Kvar kunne du finne alle dei **21** påskeegga? 🤔
 Vel, min kjære lesar. Dette treng du ikkje lenger lure på, for her kjem nemleg den store **FASITEN** til årets påskeeggjakt! 🙌
-
 <br>
+
 |**Nummer**|**Stad**|**Bilete**|
 |**0.**|Lenkje skriven til konsollen på abakus.no.|![0](/images/posts/2024-04-13-egg-0.png)|
 |**2.**|Nederst på framsida til abakus.no.|![2](/images/posts/2024-04-13-egg-2.png)|

--- a/css/style.scss
+++ b/css/style.scss
@@ -85,12 +85,26 @@ table {
   border-spacing: 0;
   vertical-align: middle;
 }
+tr:nth-child(2n) {
+  background: #f8f8f8;
+}
+tbody:first-child {
+  td {
+    text-align: center;
+  }
+}
+th {
+  text-align: center;
+}
 caption,
 th,
 td {
-  text-align: left;
   font-weight: normal;
   vertical-align: middle;
+}
+td,
+caption {
+  text-align: left;
 }
 a img {
   border: none;


### PR DESCRIPTION
Fixes the bonus edition title, which was previously duplicated. Also improves the table styling.

| Before | After |
| -- | -- |
| ![image](https://github.com/webkom/webkom.github.io/assets/33326578/904218eb-7811-4547-8c27-dc6a5add4a1c) | ![image](https://github.com/webkom/webkom.github.io/assets/33326578/0baa2589-ff97-4af1-b83f-88bfcee164be) |
